### PR TITLE
update for elm 0.17

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "5.2.0",
+    "version": "5.2.1",
     "summary": "Extra functions for more easily building and handling Http requests",
     "repository": "https://github.com/lukewestby/elm-http-extra.git",
     "license": "MIT",
@@ -10,8 +10,8 @@
         "Http.Extra"
     ],
     "dependencies": {
-        "elm-lang/core": "3.0.0 <= v < 4.0.0",
-        "evancz/elm-http": "3.0.0 <= v < 4.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "evancz/elm-http": "3.0.1 <= v < 4.0.0"
     },
-    "elm-version": "0.16.0 <= v < 0.17.0"
+    "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/src/Http/Extra.elm
+++ b/src/Http/Extra.elm
@@ -1,11 +1,11 @@
-module Http.Extra
+module Http.Extra exposing
   ( RequestBuilder, url, get, post, put, patch, delete
   , withHeader, withHeaders, withBody, withStringBody, withJsonBody, withMultipartBody, withMultipartStringBody, withUrlEncodedBody
   , withTimeout, withStartHandler, withProgressHandler, withMimeType, withCredentials
   , send
   , BodyReader, stringReader, jsonReader, Error(..), Response
   , toRequest, toSettings, Request, Settings
-  ) where
+  )
 
 {-| Extra helpers for more easily building Http requests that require greater
 configuration than what is provided by `elm-http` out of the box.

--- a/tests/unit/elm-package.json
+++ b/tests/unit/elm-package.json
@@ -10,10 +10,9 @@
     "exposed-modules": [],
     "native-modules": true,
     "dependencies": {
-        "deadfoxygrandpa/elm-test": "3.0.0 <= v < 4.0.0",
-        "elm-lang/core": "2.0.0 <= v < 4.0.0",
-        "laszlopandy/elm-console": "1.0.1 <= v < 2.0.0",
-        "evancz/elm-http": "3.0.0 <= v < 4.0.0"
+        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "evancz/elm-http": "3.0.1 <= v < 4.0.0"
     },
-    "elm-version": "0.15.0 <= v < 0.17.0"
+    "elm-version": "0.16.0 <= v < 0.18.0"
 }


### PR DESCRIPTION
I've upgraded the package itself, but not its tests. I saw #11 and it looks like tests haven't been updated even for Elm 0.16, so I left it at that.

**Warning:** it compiles, but I couldn't test it yet - for my main app is completely broken, but I didn't yet create a small test app in Elm 0.17.
